### PR TITLE
setQuery implies resetQuery

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,7 @@ SPARQLWrapper's changelog:
 
 YYYY-MM-DD  1.5.3   - Returing raw response in case of unknow content type returned
                     - Fixed some issues with the last version of the SPARQL 1.1 Update Protocol
+                    - setQuery() doesn't imply resetQuery() anymore
 
 2012-08-28  1.5.2   - Implemented update operation according the latest SPARQL 1.1 Protocol drafts (i.e., switching to 'update' parameter)
 

--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -221,7 +221,7 @@ class SPARQLWrapper :
         self.user = user
         self.passwd = passwd
 
-    def setQuery(self,query) :
+    def setQuery(self, query):
         """
             Set the SPARQL query text. Note: no check is done on the validity of the query 
             (syntax or otherwise) by this module, except for testing the query type (SELECT, 
@@ -230,7 +230,6 @@ class SPARQLWrapper :
             @type query: string
             @bug: #2320024
         """
-        self.resetQuery()
         self.queryString = query
         self.queryType   = self._parseQueryType(query)
 


### PR DESCRIPTION
right now, code for `setQuery` is started by a call to `resetQuery()`. Is that intentional?

It complicates reusage as I need to specify all "custom" parameters for each query even if I do several similar queries in row.
