### PR TITLE
Constructor duplicates resetQuery() code

### DIFF
--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -130,21 +130,14 @@ class SPARQLWrapper:
         self.agent = agent
         self.user = None
         self.passwd = None
-        self.customParameters = {}
         self._defaultGraph = defaultGraph
 
-        if defaultGraph:
-            self.customParameters["default-graph-uri"] = defaultGraph
-
         if returnFormat in _allowedFormats:
-            self.returnFormat = returnFormat
+            self._defaultReturnFormat = returnFormat
         else:
-            self.returnFormat = XML
+            self._defaultReturnFormat = XML
 
-        self._defaultReturnFormat = self.returnFormat
-        self.queryString = """SELECT * WHERE{ ?s ?p ?o }"""
-        self.method = GET
-        self.queryType = SELECT
+        self.resetQuery()
 
     def resetQuery(self):
         """Reset the query, ie, return format, query, default or named graph settings, etc,


### PR DESCRIPTION
Right now constructor contains all the lines which `resetQuery()` method minus intermediate var-name quirks. This pull-request fixes this + adds better pep8 compliance (just for related methods) + removes a tiny piece of dead code
