### PR TITLE
CREATE, CLEAR, DROP, LOAD, COPY and MOVE query types added

### DIFF
--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -58,7 +58,16 @@ DESCRIBE   = "DESCRIBE"
 INSERT     = "INSERT"
 DELETE     = "DELETE"
 MODIFY     = "MODIFY"
-_allowedQueryTypes = [SELECT, CONSTRUCT, ASK, DESCRIBE, INSERT, DELETE, MODIFY]
+CREATE     = "CREATE"
+CLEAR      = "CLEAR"
+DROP       = "DROP"
+LOAD       = "LOAD"
+COPY       = "COPY"
+MOVE       = "MOVE"
+ADD        = "ADD"
+
+_allowedQueryTypes = [SELECT, CONSTRUCT, ASK, DESCRIBE, INSERT, DELETE, MODIFY, CREATE, CLEAR, DROP,
+                      LOAD, COPY, MOVE, ADD]
 
 # Possible output format (mime types) that can be converted by the local script. Unfortunately,
 # it does not work by simply setting the return format, because there is still a certain level of confusion
@@ -111,8 +120,8 @@ class SPARQLWrapper(object):
     @ivar baseURI: the URI of the SPARQL service
     """
     pattern = re.compile(r"""
-                ((?P<base>(\s*BASE\s*<.*?>)\s*)|(?P<prefixes>(\s*PREFIX\s+.+:\s*<.*?>)\s*))*
-                (?P<queryType>(CONSTRUCT|SELECT|ASK|DESCRIBE|INSERT|DELETE|MODIFY))
+        ((?P<base>(\s*BASE\s*<.*?>)\s*)|(?P<prefixes>(\s*PREFIX\s+.+:\s*<.*?>)\s*))*
+        (?P<queryType>(CONSTRUCT|SELECT|ASK|DESCRIBE|INSERT|DELETE|MODIFY|CREATE|CLEAR|DROP|LOAD|COPY|MOVE|ADD))
     """, re.VERBOSE | re.IGNORECASE)
 
     def __init__(self, endpoint, updateEndpoint=None, returnFormat=XML, defaultGraph=None, agent=__agent__):
@@ -333,7 +342,7 @@ class SPARQLWrapper(object):
         """ Returns TRUE if SPARQLWrapper is configured for executing SPARQL Update request
         @return: bool
         """
-        return self.queryType in [INSERT, DELETE, MODIFY]
+        return self.queryType in [INSERT, DELETE, MODIFY, CREATE, CLEAR, DROP, LOAD, COPY, MOVE, ADD]
 
     def isSparqlQueryRequest(self):
         """ Returns TRUE if SPARQLWrapper is configured for executing SPARQL Query request

--- a/test/wrapper_test.py
+++ b/test/wrapper_test.py
@@ -205,11 +205,38 @@ class SPARQLWrapper_Test(unittest.TestCase):
         self.wrapper.setQuery('DELETE WHERE {?s ?p ?o}')
         self.assertTrue(self.wrapper.isSparqlUpdateRequest())
 
+        self.wrapper.setQuery('DELETE DATA { <urn:john> <urn:likes> <urn:surfing> }')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
         self.wrapper.setQuery("""
         PREFIX example: <http://example.org/SELECT/>
         BASE <http://example.org/SELECT>
         DELETE WHERE {?s ?p ?o}
         """)
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('INSERT DATA { <urn:john> <urn:likes> <urn:surfing> }')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('CREATE GRAPH <urn:graph>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('CLEAR GRAPH <urn:graph>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('DROP GRAPH <urn:graph>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('MOVE GRAPH <urn:graph1> TO GRAPH <urn:graph2>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('LOAD <http://localhost/file.rdf> INTO GRAPH <urn:graph>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('COPY <urn:graph1> TO GRAPH <urn:graph2>')
+        self.assertTrue(self.wrapper.isSparqlUpdateRequest())
+
+        self.wrapper.setQuery('ADD <urn:graph1> TO GRAPH <urn:graph2>')
         self.assertTrue(self.wrapper.isSparqlUpdateRequest())
 
     def testIsSparqlQueryRequest(self):
@@ -222,6 +249,7 @@ class SPARQLWrapper_Test(unittest.TestCase):
         ASK WHERE {?s ?p ?o}
         """)
         self.assertTrue(self.wrapper.isSparqlQueryRequest())
+        self.assertFalse(self.wrapper.isSparqlUpdateRequest())
 
     def testQuery(self):
         qr = self.wrapper.query()


### PR DESCRIPTION
Support graph management query types : CREATE, CLEAR, DROP, LOAD, COPY, MOVE and ADD.

Should fix a regression mentioned in  https://github.com/RDFLib/rdflib/pull/397 .
