### PR TITLE
Test correct value of basic authorization header

### DIFF
--- a/test/wrapper_test.py
+++ b/test/wrapper_test.py
@@ -230,7 +230,9 @@ class SPARQLWrapper_Test(TestCase):
         self.wrapper.setCredentials('login', 'password')
         request = self._get_request(self.wrapper)
         self.assertTrue(request.has_header('Authorization'))
-        # TODO: test for header-value using some external decoder implementation
+        
+        # expected header for admin:password
+        self.assertEqual("Basic bG9naW46cGFzc3dvcmQ=", request.get_header('Authorization'))
 
     def testSetHTTPAuth(self):
         self.assertRaises(TypeError, self.wrapper.setHTTPAuth, 123)


### PR DESCRIPTION
We ran into a bug with basic http authorization. I noticed you recently fixed this - great. Here I contribute a test for this issue. I've checked that it fails with revision 3a6118 and succeeds with the current version.

Are the tests supposed to be ran on python 3?