### PR TITLE
Remove dependency on pip during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ try:
     _install_requires = [str(r.req) for r in requirements]
 except:
     with open('requirements.txt', 'r') as f:
-        for line in f:
-            _install_requires = [line.rstrip('\n') for line in f]
+        _install_requires = [line.rstrip('\n') for line in f]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,8 @@ else:
 
 
 # requirements
-try:
-    from pip.req import parse_requirements
-    from pip.download import PipSession
-    requirements = list(parse_requirements('requirements.txt', session=PipSession()))
-    _install_requires = [str(r.req) for r in requirements]
-except:
-    with open('requirements.txt', 'r') as f:
-        _install_requires = [line.rstrip('\n') for line in f]
+with open('requirements.txt', 'r') as f:
+    _install_requires = [line.rstrip('\n') for line in f]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,15 @@ else:
 
 
 # requirements
-from pip.req import parse_requirements
-from pip.download import PipSession
-requirements = list(parse_requirements('requirements.txt', session=PipSession()))
-_requires = [str(r.req.project_name) for r in requirements]
-_install_requires = [str(r.req) for r in requirements]
+try:
+    from pip.req import parse_requirements
+    from pip.download import PipSession
+    requirements = list(parse_requirements('requirements.txt', session=PipSession()))
+    _install_requires = [str(r.req) for r in requirements]
+except:
+    with open('requirements.txt', 'r') as f:
+        for line in f:
+            _install_requires = [line.rstrip('\n') for line in f]
 
 
 setup(
@@ -59,7 +63,6 @@ setup(
       download_url = 'https://github.com/RDFLib/sparqlwrapper/releases',
       platforms = ['any'],
       packages = ['SPARQLWrapper'],
-      requires = _requires,
       install_requires = _install_requires,
       classifiers =  [
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This PR tries to remove `pip` dependency on setup, as it's being discussed in PR #68, but at the same time it keeps requirements in a single place.