### PR TITLE
Add support for rdf+xml

### DIFF
--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -4,6 +4,7 @@
 """
 @var JSON: to be used to set the return format to JSON
 @var XML: to be used to set the return format to XML (SPARQL XML format or RDF/XML, depending on the query type). This is the default.
+@var RDFXML: to be used to set the return format to RDF/XML explicitly.
 @var TURTLE: to be used to set the return format to Turtle
 @var N3: to be used to set the return format to N3 (for most of the SPARQL services this is equivalent to Turtle)
 @var RDF: to be used to set the return RDF Graph
@@ -45,7 +46,8 @@ XML    = "xml"
 TURTLE = "turtle"
 N3     = "n3"
 RDF    = "rdf"
-_allowedFormats = [JSON, XML, TURTLE, N3, RDF]
+RDFXML = "rdf+xml"
+_allowedFormats = [JSON, XML, TURTLE, N3, RDF, RDFXML]
 
 # Possible HTTP methods
 POST = "POST"
@@ -106,11 +108,11 @@ except ImportError:
     #warnings.warn("JSON-LD disabled because no suitable support has been found", RuntimeWarning)
     pass
 
-# This is very ugly. The fact is that the key for the choice of the output format is not defined. 
-# Virtuoso uses 'format', joseki uses 'output', rasqual seems to use "results", etc. Lee Feigenbaum 
-# told me that virtuoso also understand 'output' these days, so I removed 'format'. I do not have 
-# info about the others yet, ie, for the time being I keep the general mechanism. Hopefully, in a 
-# future release, I can get rid of that. However, these processors are (hopefully) oblivious to the 
+# This is very ugly. The fact is that the key for the choice of the output format is not defined.
+# Virtuoso uses 'format', joseki uses 'output', rasqual seems to use "results", etc. Lee Feigenbaum
+# told me that virtuoso also understand 'output' these days, so I removed 'format'. I do not have
+# info about the others yet, ie, for the time being I keep the general mechanism. Hopefully, in a
+# future release, I can get rid of that. However, these processors are (hopefully) oblivious to the
 # parameters they do not understand. So: just repeat all possibilities in the final URI. UGLY!!!!!!!
 _returnFormatSetting = ["format", "output", "results"]
 
@@ -213,7 +215,7 @@ class SPARQLWrapper(object):
 
     def setRequestMethod(self, method):
         """Set the internal method to use to perform the request for query or
-        update operations, either URL-encoded (C{SPARQLWrapper.URLENCODED}) or 
+        update operations, either URL-encoded (C{SPARQLWrapper.URLENCODED}) or
         POST directly (C{SPARQLWrapper.POSTDIRECTLY}).
         Further details at U{http://www.w3.org/TR/sparql11-protocol/#query-operation}
         and U{http://www.w3.org/TR/sparql11-protocol/#update-operation}.
@@ -250,7 +252,7 @@ class SPARQLWrapper(object):
     def addExtraURITag(self, key, value):
         """
             Some SPARQL endpoints require extra key value pairs.
-            E.g., in virtuoso, one would add C{should-sponge=soft} to the query forcing 
+            E.g., in virtuoso, one would add C{should-sponge=soft} to the query forcing
             virtuoso to retrieve graphs that are not stored in its local database.
             @param key: key of the query part
             @type key: string
@@ -264,7 +266,7 @@ class SPARQLWrapper(object):
     def addCustomParameter(self, name, value):
         """
             Method is kept for backwards compatibility. Historically, it "replaces" parameters instead of adding
-            @param name: name 
+            @param name: name
             @type name: string
             @param value: value
             @type value: string
@@ -277,9 +279,9 @@ class SPARQLWrapper(object):
     def addParameter(self, name, value):
         """
             Some SPARQL endpoints allow extra key value pairs.
-            E.g., in virtuoso, one would add C{should-sponge=soft} to the query forcing 
+            E.g., in virtuoso, one would add C{should-sponge=soft} to the query forcing
             virtuoso to retrieve graphs that are not stored in its local database.
-            @param name: name 
+            @param name: name
             @type name: string
             @param value: value
             @type value: string
@@ -296,7 +298,7 @@ class SPARQLWrapper(object):
     def clearParameter(self, name):
         """
             Clear the values ofd a concrete parameter.
-            @param name: name 
+            @param name: name
             @type name: string
             @rtype: bool
         """
@@ -333,11 +335,11 @@ class SPARQLWrapper(object):
         else:
             valid_types = ", ".join(_allowedAuth)
             raise ValueError("Value should be one of {0}".format(valid_types))
-                    
+
     def setQuery(self, query):
         """
-            Set the SPARQL query text. Note: no check is done on the validity of the query 
-            (syntax or otherwise) by this module, except for testing the query type (SELECT, 
+            Set the SPARQL query text. Note: no check is done on the validity of the query
+            (syntax or otherwise) by this module, except for testing the query type (SELECT,
             ASK, etc). Syntax and validity checking is done by the SPARQL service itself.
             @param query: query text
             @type query: string
@@ -381,7 +383,7 @@ class SPARQLWrapper(object):
         except AttributeError:
             warnings.warn("not detected query type for query '%s'" % query.replace("\n", " "), RuntimeWarning)
             r_queryType = None
-    
+
         if r_queryType in _allowedQueryTypes :
             return r_queryType
         else :
@@ -716,7 +718,7 @@ class QueryResult(object):
                 _validate_format("JSON", [JSON], ct, self.requestedFormat)
                 return self._convertJSON()
             elif _content_type_in_list(ct, _RDF_XML):
-                _validate_format("RDF/XML", [RDF, XML], ct, self.requestedFormat)
+                _validate_format("RDF/XML", [RDF, XML, RDFXML], ct, self.requestedFormat)
                 return self._convertRDF()
             elif _content_type_in_list(ct, _RDF_N3):
                 _validate_format("N3", [N3, TURTLE], ct, self.requestedFormat)

--- a/SPARQLWrapper/__init__.py
+++ b/SPARQLWrapper/__init__.py
@@ -185,7 +185,7 @@ __agent__   = "sparqlwrapper %s (rdflib.github.io/sparqlwrapper)" % __version__
 
 
 from Wrapper import SPARQLWrapper
-from Wrapper import XML, JSON, TURTLE, N3, JSONLD, RDF
+from Wrapper import XML, JSON, TURTLE, N3, JSONLD, RDF, RDFXML
 from Wrapper import GET, POST
 from Wrapper import SELECT, CONSTRUCT, ASK, DESCRIBE, INSERT, DELETE
 from Wrapper import URLENCODED, POSTDIRECTLY

--- a/test/wrapper_test.py
+++ b/test/wrapper_test.py
@@ -24,7 +24,7 @@ if _top_level_path not in sys.path:
 # end of hack
 
 from SPARQLWrapper import SPARQLWrapper
-from SPARQLWrapper import XML, GET, POST, JSON, JSONLD, N3, TURTLE, RDF, SELECT, INSERT
+from SPARQLWrapper import XML, GET, POST, JSON, JSONLD, N3, TURTLE, RDF, SELECT, INSERT, RDFXML
 from SPARQLWrapper import URLENCODED, POSTDIRECTLY
 from SPARQLWrapper import BASIC, DIGEST
 from SPARQLWrapper.Wrapper import QueryResult, QueryBadFormed, EndPointNotFound, EndPointInternalError
@@ -189,7 +189,7 @@ class SPARQLWrapper_Test(TestCase):
         try:
             import rdflib_jsonld
             self.wrapper.setReturnFormat(JSONLD)
-            self.assertEqual(JSONLD, self.wrapper.query().requestedFormat)   
+            self.assertEqual(JSONLD, self.wrapper.query().requestedFormat)
         except ImportError:
             self.assertRaises(ValueError, self.wrapper.setReturnFormat, JSONLD)
 
@@ -199,6 +199,7 @@ class SPARQLWrapper_Test(TestCase):
         self.assertTrue(self.wrapper.supportsReturnFormat(TURTLE))
         self.assertTrue(self.wrapper.supportsReturnFormat(N3))
         self.assertTrue(self.wrapper.supportsReturnFormat(RDF))
+        self.assertTrue(self.wrapper.supportsReturnFormat(RDFXML))
         self.assertFalse(self.wrapper.supportsReturnFormat('nonexistent format'))
 
         try:
@@ -229,7 +230,7 @@ class SPARQLWrapper_Test(TestCase):
         self.wrapper.setCredentials('login', 'password')
         request = self._get_request(self.wrapper)
         self.assertTrue(request.has_header('Authorization'))
-        
+
         # expected header for login:password
         # should succeed for python 3 since pull request #72
         self.assertEqual("Basic bG9naW46cGFzc3dvcmQ=", request.get_header('Authorization'))
@@ -260,11 +261,11 @@ class SPARQLWrapper_Test(TestCase):
 
         self.wrapper.setQuery('PREFIX e: <http://example.org/> INSERT {e:a e:b e:c}')
         self.assertEqual(INSERT, self.wrapper.queryType)
-        
-        self.wrapper.setQuery("""#CONSTRUCT {?s ?p ?o} 
+
+        self.wrapper.setQuery("""#CONSTRUCT {?s ?p ?o}
                                    SELECT ?s ?p ?o
                                    WHERE {?s ?p ?o}""")
-        self.assertEqual(SELECT, self.wrapper.queryType)        
+        self.assertEqual(SELECT, self.wrapper.queryType)
 
         with warnings.catch_warnings(record=True) as w:
             self.wrapper.setQuery('UNKNOWN {e:a e:b e:c}')
@@ -576,6 +577,7 @@ class QueryResult_Test(unittest.TestCase):
         self.assertEqual(0, _mime_vs_type("application/ld+json", JSONLD))
         self.assertEqual(0, _mime_vs_type("application/rdf+xml", XML))
         self.assertEqual(0, _mime_vs_type("application/rdf+xml", RDF))
+        self.assertEqual(0, _mime_vs_type("application/rdf+xml", RDFXML))
 
         self.assertEqual(1, _mime_vs_type("application/x-foo-bar", XML), "invalid mime")
 


### PR DESCRIPTION
When sending update requests to the SPARQL endpoint, I was getting the following error message:

```
Parameter "format" must be one of "rdf+xml", "json", "csv", "application/sparql-results+xml" or "application/sparql-results+json".  Found "xml".
```

After setting return format to `rdf+xml` my update was accepted by the endpoint.

This PR allows to set return format to `rdf+xml` explicitly.