### PR TITLE
Drop keepalive from requirements.txt (Closes: #846871)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 rdflib>=4.0
-keepalive>=0.5

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(
       platforms = ['any'],
       packages = ['SPARQLWrapper'],
       install_requires = _install_requires,
+      extras_require = {
+        'keepalive': ['keepalive>=0.5'],
+      },
       classifiers =  [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
As keepalive support is a weak dependency (absence makes keepalive enabling only raise a warning and otherwise a no-op), listing it as a dependency causes trouble with test setups. Demoting it to an extra (feature) dependency.

----
The hard dependency statement has [caused trouble with test setups](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=846871) where the contentually unnecessary keepalive package caused a dependency failure. Please consider classifying keepalive as a feature dependency as above or similar.