### PR TITLE
do not re-install urllib2 keepalive handler if already present

### DIFF
--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -455,6 +455,11 @@ class SPARQLWrapper(object):
         """
         try:
             from keepalive import HTTPHandler
+
+            if urllib2._opener and any(isinstance(h, HTTPHandler) for h in urllib2._opener.handlers):
+                # already installed
+                return
+
             keepalive_handler = HTTPHandler()
             opener = urllib2.build_opener(keepalive_handler)
             urllib2.install_opener(opener)


### PR DESCRIPTION
For some reason I don't understand, my code will sometimes freeze when using an RDFLib SPARQLStore with multiprocessing. 

After much much debugging I realised that the sub-process will freeze on setting up keep-alive. In fact, the `build_opener` call never returns. I don't know _WHY_ that happens though. Reading the urllib2 code there doesn't seem to by anything threading/process related. There is a lock in the keepalive code: https://github.com/wikier/keepalive/blob/master/keepalive/keepalive.py#L124

My best theory is that this is acquired in the parent process, while it's acquired the process forks. The child process inherits the lock in acquired state, but it's never freed in the child when freed in the parent. 

It doesn't happen every time, and I cannot reproduce in a simple test :( It may only happen on osx.

In any case, this fixes it, and shouldn't harm anyone else, in fact, it should make creating the store slightly faster for everyone :) 

This is similar to this issue in NLTK: https://github.com/nltk/nltk/issues/947