### PR TITLE
Mention SPARQLWrapper2 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ From Debian
 
 Create an instance to execute your query:
 
-```
+```python
 from SPARQLWrapper import SPARQLWrapper, JSON
 
 sparql = SPARQLWrapper("http://dbpedia.org/sparql")
@@ -39,7 +39,23 @@ sparql.setReturnFormat(JSON)
 results = sparql.query().convert()
 
 for result in results["results"]["bindings"]:
-    print(result["label"]["value"])
+    print('%s: %s' % (result["label"]["xml:lang"], result["label"]["value"]))
+```
+
+There is also a `SPARQLWrapper2` class that works with JSON results only and wraps the results to make processing of average queries a bit simpler.
+
+```python
+from SPARQLWrapper import SPARQLWrapper2
+
+sparql = SPARQLWrapper2("http://dbpedia.org/sparql")
+sparql.setQuery("""
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    SELECT ?label
+    WHERE { <http://dbpedia.org/resource/Asturias> rdfs:label ?label }
+""")
+
+for result in sparql.query().bindings:
+    print('%s: %s' % (result["label"].lang, result["label"].value))
 ```
 
 ## Source code


### PR DESCRIPTION
With the current example in the readme as the only, it looks like SPARQLWrapper is rather cumbersome to use. I feel like it's worth mentioning the SPARQLWrapper2 class right-away.