### PR TITLE
Cli

### DIFF
--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -3,13 +3,15 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-from .Wrapper import SPARQLWrapper, _allowedFormats
-from . import __version__
+import json
 import os
 from pprint import pprint
-import json
-import rdflib
 from shutil import get_terminal_size
+
+import rdflib
+
+from . import __version__
+from .Wrapper import SPARQLWrapper, _allowedFormats
 
 
 class SPARQLWrapperFormatter(

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -1,0 +1,41 @@
+import argparse
+
+from . import __version__
+
+# TODO: endpoint query, format
+
+def parse_args() -> argparse.Namespace:
+    """Parse arguments."""
+    parser = argparse.ArgumentParser(
+        prog="shindan",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="ShindanMaker (https://shindanmaker.com) CLI",
+    )
+    parser.add_argument(
+        "page_id", metavar="ID", type=check_natural, help="shindan page id"
+    )
+    parser.add_argument("shindan_name", metavar="NAME", type=str, help="shindan name")
+    parser.add_argument("-w", "--wait", action="store_true", help="insert random wait")
+    parser.add_argument(
+        "-H", "--hashtag", action="store_true", help= "add hashtag `#shindanmaker`"
+    )
+    parser.add_argument(
+        "-l", "--link", action="store_true", help="add link to last of output"
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version="%(prog)s {}".format(__version__)
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(shindan.shindan(args.page_id, args.shindan_name, wait=args.wait))
+    if args.hashtag:
+        print("#shindanmaker")
+    if args.link:
+        print("https://shindanmaker.com/%d" % args.page_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -33,7 +33,7 @@ def choicesDescriptions():
     return "\n  - ".join(["allowed formats:"] + _allowedFormats)
 
 
-def parse_args():
+def parse_args(test=None):
     """Parse arguments."""
     parser = argparse.ArgumentParser(
         prog="rqw",
@@ -78,11 +78,14 @@ def parse_args():
     parser.add_argument(
         "-V", "--version", action="version", version="%(prog)s {}".format(__version__)
     )
-    return parser.parse_args()
+    if test is None:
+        return parser.parse_args()
+    else:
+        return parser.parse_args(test)
 
 
-def main():
-    args = parse_args()
+def main(test=None):
+    args = parse_args(test)
     if args.quiet:
         import warnings
 

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -56,7 +56,6 @@ def parse_args(test=None):
         metavar="FILE",
         type=check_file,
         help="query with sparql file (stdin: -)",
-        default="-",
     )
     input_group.add_argument("-Q", "--query", metavar="QUERY", help="query with string")
     parser.add_argument(

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -5,10 +5,10 @@
 import argparse
 import json
 import os
-from pprint import pprint
+import sys
 from shutil import get_terminal_size
 
-import rdflib
+import rdflib  # type: ignore
 
 from . import __version__
 from .Wrapper import SPARQLWrapper, _allowedFormats
@@ -33,7 +33,7 @@ def choicesDescriptions():
     return "\n  - ".join(["allowed formats:"] + _allowedFormats)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args():
     """Parse arguments."""
     parser = argparse.ArgumentParser(
         prog="rqw",
@@ -81,7 +81,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
+def main():
     args = parse_args()
     if args.quiet:
         import warnings
@@ -111,13 +111,13 @@ def main() -> None:
     if args.format == "json":
         print(json.dumps(results, indent=4))
     elif args.format in ("xml", "rdf+xml", "json-ld"):
-        print(results.toxml())
+        print(results.toxml())  # type: ignore
     elif args.format == "n3":
         g = rdflib.Graph()
-        g.parse(data=results, format="n3")
+        g.parse(data=results, format="n3")  # type: ignore
         print(g.serialize(format="n3"))
     elif args.format in ("csv", "tsv", "turtle"):
-        print(results.decode("utf-8"))
+        print(results.decode("utf-8"))  # type: ignore
     else:
         print(results)
 

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -26,7 +26,7 @@ def check_file(v):
     elif v == "-":
         return "-"  # stdin
     else:
-        raise OSError("file '%s' is not found" % v)
+        raise argparse.ArgumentError("file '%s' is not found" % v)
 
 
 def choicesDescriptions():

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Documentation': 'https://sparqlwrapper.readthedocs.io',
         'Source': 'https://github.com/RDFLib/sparqlwrapper',
         'Tracker': 'https://github.com/RDFLib/sparqlwrapper/issues',
+    },
     entry_points={
         'console_scripts': [
             'rqw=SPARQLWrapper.main:main'

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,9 @@ setup(
         'Documentation': 'https://sparqlwrapper.readthedocs.io',
         'Source': 'https://github.com/RDFLib/sparqlwrapper',
         'Tracker': 'https://github.com/RDFLib/sparqlwrapper/issues',
+    entry_points={
+        'console_scripts': [
+            'rqw=SPARQLWrapper.main:main'
+        ]
     }
 )

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,39 +1,133 @@
 # -*- coding: utf-8 -*-
-import os
 import inspect
-import unittest
+import io
+import os
 import sys
+import textwrap
+import unittest
 
 # prefer local copy to the one which is installed
 # hack from http://stackoverflow.com/a/6098238/280539
-_top_level_path = os.path.realpath(os.path.abspath(os.path.join(
-    os.path.split(inspect.getfile(inspect.currentframe()))[0],
-    ".."
-)))
+_top_level_path = os.path.realpath(
+    os.path.abspath(
+        os.path.join(os.path.split(inspect.getfile(inspect.currentframe()))[0], "..")
+    )
+)
 if _top_level_path not in sys.path:
     sys.path.insert(0, _top_level_path)
 # end of hack
 
-from SPARQLWrapper.main import parse_args, main
+from SPARQLWrapper.main import main, parse_args
+
 
 class SPARQLWrapper_Test(unittest.TestCase):
+    def setUp(self):
+        self.org_stdout, sys.stdout = sys.stdout, io.StringIO()
+        self.org_stderr, sys.stderr = sys.stderr, io.StringIO()
+
+    def tearDown(self):
+        sys.stdout = self.org_stdout
 
     def testHelp(self):
         with self.assertRaises(SystemExit) as cm:
-            parse_args(['-h'])
+            parse_args(["-h"])
 
         self.assertEqual(cm.exception.code, 0)
-
+        self.assertEqual(sys.stdout.getvalue()[:5], "usage")
 
     def testVersion(self):
         with self.assertRaises(SystemExit) as cm:
-            parse_args(['-V'])
+            parse_args(["-V"])
 
         self.assertEqual(cm.exception.code, 0)
-
+        self.assertEqual(sys.stdout.getvalue()[:3], "rqw")
 
     def testNoarg(self):
         with self.assertRaises(SystemExit) as cm:
             parse_args([])
 
-        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(
+            sys.stderr.getvalue().split("\n")[1],
+            "rqw: error: one of the arguments -f/--file -Q/--query is required",
+        )
+
+    def testQueryAndFile(self):
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["-Q", "SELECT ?s WHERE { ?s ?p ?o. } limit 1", "-f", "-"])
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(
+            sys.stderr.getvalue().split("\n")[1],
+            "rqw: error: argument -f/--file: not allowed with argument -Q/--query",
+        )
+
+    def testQueryWithEndpoint(self):
+        main(
+            [
+                "-Q",
+                "SELECT ?s WHERE { ?s ?p ?o. } limit 1",
+                "-e",
+                "http://ja.dbpedia.org/sparql",
+            ]
+        )
+
+        self.assertEqual(
+            sys.stdout.getvalue(),
+            textwrap.dedent(
+                """\
+            {
+                "head": {
+                    "link": [],
+                    "vars": [
+                        "s"
+                    ]
+                },
+                "results": {
+                    "distinct": false,
+                    "ordered": true,
+                    "bindings": [
+                        {
+                            "s": {
+                                "type": "uri",
+                                "value": "http://www.openlinksw.com/virtrdf-data-formats#default-iid"
+                            }
+                        }
+                    ]
+                }
+            }
+            """
+            ),
+        )
+
+    def testQueryWithFile(self):
+        main(["-f", "test.rq", "-e", "http://ja.dbpedia.org/sparql"])
+
+        self.assertEqual(
+            sys.stdout.getvalue(),
+            textwrap.dedent(
+                """\
+            {
+                "head": {
+                    "link": [],
+                    "vars": [
+                        "pllabel"
+                    ]
+                },
+                "results": {
+                    "distinct": false,
+                    "ordered": true,
+                    "bindings": [
+                        {
+                            "pllabel": {
+                                "type": "literal",
+                                "xml:lang": "ja",
+                                "value": "ABC (\\u30d7\\u30ed\\u30b0\\u30e9\\u30df\\u30f3\\u30b0\\u8a00\\u8a9e)"
+                            }
+                        }
+                    ]
+                }
+            }
+            """
+            ),
+        )

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -19,6 +19,7 @@ if _top_level_path not in sys.path:
 
 from SPARQLWrapper.main import main, parse_args
 
+endpoint = "http://ja.dbpedia.org/sparql"
 testfile = os.path.join(os.path.dirname(__file__), 'test.rq')
 
 class SPARQLWrapperCLI_Test_Base(unittest.TestCase):
@@ -95,7 +96,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
                 "-Q",
                 "SELECT ?s WHERE { ?s ?p ?o. } limit 1",
                 "-e",
-                "http://ja.dbpedia.org/sparql",
+                endpoint,
             ]
         )
 
@@ -128,7 +129,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFile(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql"])
+        main(["-f", testfile, "-e", endpoint])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -160,7 +161,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFileXML(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "xml"])
+        main(["-f", testfile, "-e", endpoint, "-F", "xml"])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -181,7 +182,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFileTurtle(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "turtle"])
+        main(["-f", testfile, "-e", endpoint, "-F", "turtle"])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -203,7 +204,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
                 "-f",
                 testfile,
                 "-e",
-                "http://ja.dbpedia.org/sparql",
+                endpoint,
                 "-F",
                 "turtle",
                 "-q",
@@ -225,7 +226,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFileN3(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "n3"])
+        main(["-f", testfile, "-e", endpoint, "-F", "n3"])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -241,7 +242,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     # def testQueryWithFileRDF(self):
-    #     main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "rdf"])
+    #     main(["-f", testfile, "-e", endpoint, "-F", "rdf"])
     #
     #     self.assertEqual(
     #         sys.stdout.getvalue(),
@@ -251,7 +252,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
     #     )
 
     def testQueryWithFileRDFXML(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "rdf+xml"])
+        main(["-f", testfile, "-e", endpoint, "-F", "rdf+xml"])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -272,7 +273,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFileCSV(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "csv"])
+        main(["-f", testfile, "-e", endpoint, "-F", "csv"])
 
         self.assertEqual(
             sys.stdout.getvalue(),
@@ -285,7 +286,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryWithFileTSV(self):
-        main(["-f", testfile, "-e", "http://ja.dbpedia.org/sparql", "-F", "tsv"])
+        main(["-f", testfile, "-e", endpoint, "-F", "tsv"])
 
         self.assertEqual(
             sys.stdout.getvalue(),

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import os
+import inspect
+import unittest
+import sys
+
+# prefer local copy to the one which is installed
+# hack from http://stackoverflow.com/a/6098238/280539
+_top_level_path = os.path.realpath(os.path.abspath(os.path.join(
+    os.path.split(inspect.getfile(inspect.currentframe()))[0],
+    ".."
+)))
+if _top_level_path not in sys.path:
+    sys.path.insert(0, _top_level_path)
+# end of hack
+
+from SPARQLWrapper.main import parse_args, main
+
+class SPARQLWrapper_Test(unittest.TestCase):
+
+    def testHelp(self):
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(['-h'])
+
+        self.assertEqual(cm.exception.code, 0)
+
+
+    def testVersion(self):
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(['-V'])
+
+        self.assertEqual(cm.exception.code, 0)
+
+
+    def testNoarg(self):
+        with self.assertRaises(SystemExit) as cm:
+            parse_args([])
+
+        self.assertEqual(cm.exception.code, 1)

--- a/test/test.rq
+++ b/test/test.rq
@@ -1,0 +1,8 @@
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+select distinct ?pllabel
+where {
+  ?pl
+    a dbo:ProgrammingLanguage;
+    rdfs:label ?pllabel
+} order by ?pllabel limit 1

--- a/test/test.rq
+++ b/test/test.rq
@@ -1,8 +1,9 @@
 PREFIX dbo: <http://dbpedia.org/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-select distinct ?pllabel
-where {
+SELECT DISTINCT ?pllabel
+WHERE {
   ?pl
     a dbo:ProgrammingLanguage;
-    rdfs:label ?pllabel
-} order by ?pllabel limit 1
+    rdfs:label ?pllabel.
+  FILTER(SUBSTR(STR(?pllabel), 1, 1) = "P")
+} ORDER BY ?pllabel LIMIT 1


### PR DESCRIPTION
```shellsession
$ rqw -h
usage: rqw [-h] (-f FILE | -Q QUERY) [-F FORMAT] [-e URI] [-q] [-V]

sparqlwrapper CLI

optional arguments:
  -h, --help                  show this help message and exit
  -f FILE, --file FILE        query with sparql file (stdin: -) (default: None)
  -Q QUERY, --query QUERY     query with string (default: None)
  -F FORMAT, --format FORMAT  response format (default: json)
  -e URI, --endpoint URI      sparql endpoint (default: http://dbpedia.org/sparql)
  -q, --quiet                 supress warnings (default: False)
  -V, --version               show program's version number and exit

allowed formats:
  - json
  - xml
  - turtle
  - n3
  - rdf
  - rdf+xml
  - csv
  - tsv

$ rqw -Q 'SELECT ?s WHERE { ?s ?p ?o. } limit 1'
{
    "head": {
        "link": [],
        "vars": [
            "s"
        ]
    },
    "results": {
        "distinct": false,
        "ordered": true,
        "bindings": [
            {
                "s": {
                    "type": "uri",
                    "value": "http://www.openlinksw.com/virtrdf-data-formats#default-iid"
                }
            }
        ]
    }
}
```