### PR TITLE
Add cli options

### DIFF
--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -83,7 +83,7 @@ def parse_args(test=None):
         default="http://dbpedia.org/sparql",
     )
     parser.add_argument(
-        "-m", "--method", default=GET, metavar="METHOD", choices=_allowedRequests, help="request method"
+        "-m", "--method", metavar="METHOD", choices=_allowedRequests, help="request method"
     )
     parser.add_argument(
         "-a", "--auth", metavar="AUTH", choices=_allowedAuth ,help="HTTP auth"
@@ -130,7 +130,8 @@ def main(test=None):
     if args.auth is not None:
         sparql.setHTTPAuth(args.auth)
         sparql.setCredentials(args.username, args.password)
-    sparql.setMethod(args.method)
+    if args.method is not None:
+        sparql.setMethod(args.method)
     sparql.setQuery(q)
     sparql.setReturnFormat(args.format)
     results = sparql.query().convert()

--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -11,7 +11,7 @@ from shutil import get_terminal_size
 import rdflib  # type: ignore
 
 from . import __version__
-from .Wrapper import SPARQLWrapper, _allowedFormats
+from .Wrapper import SPARQLWrapper, _allowedFormats, _allowedRequests, _allowedAuth, GET
 
 
 class SPARQLWrapperFormatter(
@@ -30,7 +30,16 @@ def check_file(v):
 
 
 def choicesDescriptions():
-    return "\n  - ".join(["allowed formats:"] + _allowedFormats)
+    d = "\n  - ".join(
+        ["allowed FORMAT:"] + _allowedFormats
+    )
+    d += "\n  - ".join(
+        ["\n\nallowed METHOD:"] + _allowedRequests
+    )
+    d += "\n  - ".join(
+        ["\n\nallowed AUTH:"] + _allowedAuth
+    )
+    return d
 
 
 def parse_args(test=None):
@@ -73,6 +82,18 @@ def parse_args(test=None):
         help="sparql endpoint",
         default="http://dbpedia.org/sparql",
     )
+    parser.add_argument(
+        "-m", "--method", default=GET, metavar="METHOD", choices=_allowedRequests, help="request method"
+    )
+    parser.add_argument(
+        "-a", "--auth", metavar="AUTH", choices=_allowedAuth ,help="HTTP auth"
+    )
+    parser.add_argument(
+        "-u", "--username", metavar='ID', default='guest', help="username for auth"
+    )
+    parser.add_argument(
+        "-p", "--password", metavar='PW', default='', help="password for auth"
+    )
     parser.add_argument("-q", "--quiet", action="store_true", help="supress warnings")
     parser.add_argument(
         "-V", "--version", action="version", version="%(prog)s {}".format(__version__)
@@ -106,6 +127,10 @@ def main(test=None):
             "Chrome/96.0.4664.110 Safari/537.36"
         ),
     )
+    if args.auth is not None:
+        sparql.setHTTPAuth(args.auth)
+        sparql.setCredentials(args.username, args.password)
+    sparql.setMethod(args.method)
     sparql.setQuery(q)
     sparql.setReturnFormat(args.format)
     results = sparql.query().convert()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -244,16 +244,17 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             """
             ),
         )
+    @unittest.expectedFailure
+    def testQueryWithFileRDF(self):
+        main(["-f", testfile, "-e", endpoint, "-F", "rdf"])
 
-    # def testQueryWithFileRDF(self):
-    #     main(["-f", testfile, "-e", endpoint, "-F", "rdf"])
-    #
-    #     self.assertEqual(
-    #         sys.stdout.getvalue(),
-    #         textwrap.dedent(
-    #             """\
-    #         """)
-    #     )
+        self.assertEqual(
+            sys.stdout.getvalue(),
+            textwrap.dedent(
+                """\
+
+            """)
+        )
 
     def testQueryWithFileRDFXML(self):
         main(["-f", testfile, "-e", endpoint, "-F", "rdf+xml"])
@@ -604,9 +605,8 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             ),
         )
 
-    @unittest.skip("this endpoint is too slow and unstable")
     def testQueryTo4store(self):
-        main([ '-e', 'http://sparql.agroportal.lirmm.fr/sparql/', '-Q', testquery])
+        main([ '-e', 'http://rdf.chise.org/sparql', '-Q', testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
@@ -621,8 +621,8 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
                     "bindings": [
                         {
                             "x": {
-                                "type": "uri",
-                                "value": "http://purl.bioontology.org/ontology/NCBITAXON/2491102"
+                                "type": "bnode",
+                                "value": "b1f4d352f000000fc"
                             }
                         }
                     ]

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -244,7 +244,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             """
             ),
         )
-    @unittest.expectedFailure
+    @unittest.expectedFailure # rdflib.exceptions.ParserError
     def testQueryWithFileRDF(self):
         main(["-f", testfile, "-e", endpoint, "-F", "rdf"])
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -23,8 +23,9 @@ from SPARQLWrapper.main import main, parse_args
 from SPARQLWrapper import POST
 
 endpoint = "http://ja.dbpedia.org/sparql"
-testfile = os.path.join(os.path.dirname(__file__), 'test.rq')
-testquery = 'SELECT DISTINCT ?x WHERE { ?x ?y ?z . } LIMIT 1'
+testfile = os.path.join(os.path.dirname(__file__), "test.rq")
+testquery = "SELECT DISTINCT ?x WHERE { ?x ?y ?z . } LIMIT 1"
+
 
 class SPARQLWrapperCLI_Test_Base(unittest.TestCase):
     def setUp(self):
@@ -72,9 +73,7 @@ class SPARQLWrapperCLIParser_Test(SPARQLWrapperCLI_Test_Base):
 
     def testInvalidFormat(self):
         with self.assertRaises(SystemExit) as cm:
-            parse_args(
-                ["-Q", testquery, "-F", "jjssoonn"]
-            )
+            parse_args(["-Q", testquery, "-F", "jjssoonn"])
 
         self.assertEqual(cm.exception.code, 2)
         self.assertEqual(
@@ -244,7 +243,8 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             """
             ),
         )
-    @unittest.expectedFailure # rdflib.exceptions.ParserError
+
+    @unittest.expectedFailure  # rdflib.exceptions.ParserError
     def testQueryWithFileRDF(self):
         main(["-f", testfile, "-e", endpoint, "-F", "rdf"])
 
@@ -253,7 +253,8 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             textwrap.dedent(
                 """\
 
-            """)
+            """
+            ),
         )
 
     def testQueryWithFileRDFXML(self):
@@ -304,7 +305,7 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToLovFuseki(self):
-        main([ '-e', 'https://lov.linkeddata.es/dataset/lov/sparql/', '-Q', testquery])
+        main(["-e", "https://lov.linkeddata.es/dataset/lov/sparql/", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
@@ -329,12 +330,20 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
             """
             ),
         )
+
     def testQueryToRDF4J(self):
-        main([ '-e', 'http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2018-revised-corrected', '-Q', testquery])
+        main(
+            [
+                "-e",
+                "http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2018-revised-corrected",
+                "-Q",
+                testquery,
+            ]
+        )
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -357,11 +366,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToAllegroGraph(self):
-        main([ '-e', 'https://mmisw.org/sparql', '-Q', testquery])
+        main(["-e", "https://mmisw.org/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -384,11 +393,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToGraphDBEnterprise(self):
-        main([ '-e', 'http://factforge.net/repositories/ff-news', '-Q', testquery])
+        main(["-e", "http://factforge.net/repositories/ff-news", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -411,11 +420,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToStardog(self):
-        main([ '-e', 'https://lindas.admin.ch/query', '-Q', testquery, '-m', POST])
+        main(["-e", "https://lindas.admin.ch/query", "-Q", testquery, "-m", POST])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -438,11 +447,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToAgrovoc_AllegroGraph(self):
-        main([ '-e', 'https://agrovoc.fao.org/sparql', '-Q', testquery])
+        main(["-e", "https://agrovoc.fao.org/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -465,11 +474,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToVirtuosoV8(self):
-        main([ '-e', 'http://dbpedia-live.openlinksw.com/sparql', '-Q', testquery])
+        main(["-e", "http://dbpedia-live.openlinksw.com/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "link": [],
@@ -495,11 +504,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToVirtuosoV7(self):
-        main([ '-e', 'http://dbpedia.org/sparql', '-Q', testquery])
+        main(["-e", "http://dbpedia.org/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "link": [],
@@ -525,11 +534,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToBrazeGraph(self):
-        main([ '-e', 'https://query.wikidata.org/sparql', '-Q', testquery])
+        main(["-e", "https://query.wikidata.org/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -552,11 +561,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToFuseki2V3_6(self):
-        main([ '-e', 'https://agrovoc.uniroma2.it/sparql/', '-Q', testquery])
+        main(["-e", "https://agrovoc.uniroma2.it/sparql/", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -579,11 +588,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryToFuseki2V3_8(self):
-        main([ '-e', 'http://zbw.eu/beta/sparql/stw/query', '-Q', testquery])
+        main(["-e", "http://zbw.eu/beta/sparql/stw/query", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [
@@ -606,11 +615,11 @@ class SPARQLWrapperCLI_Test(SPARQLWrapperCLI_Test_Base):
         )
 
     def testQueryTo4store(self):
-        main([ '-e', 'http://rdf.chise.org/sparql', '-Q', testquery])
+        main(["-e", "http://rdf.chise.org/sparql", "-Q", testquery])
         self.assertEqual(
             sys.stdout.getvalue(),
             textwrap.dedent(
-                 """\
+                """\
             {
                 "head": {
                     "vars": [


### PR DESCRIPTION
I have added options to specify request method (`-m, --method`) and HTTPS auth (`-a, --auth`, `-u, --username`, `-p, --password`) and some testcases.

```shellsession
$ rqw -h
usage: rqw [-h] (-f FILE | -Q QUERY) [-F FORMAT] [-e URI] [-m METHOD] [-a AUTH] [-u ID] [-p PW] [-q] [-V]

sparqlwrapper CLI

optional arguments:
  -h, --help                  show this help message and exit
  -f FILE, --file FILE        query with sparql file (stdin: -) (default: None)
  -Q QUERY, --query QUERY     query with string (default: None)
  -F FORMAT, --format FORMAT  response format (default: json)
  -e URI, --endpoint URI      sparql endpoint (default: http://dbpedia.org/sparql)
  -m METHOD, --method METHOD  request method (default: None)
  -a AUTH, --auth AUTH        HTTP auth (default: None)
  -u ID, --username ID        username for auth (default: guest)
  -p PW, --password PW        password for auth (default: )
  -q, --quiet                 supress warnings (default: False)
  -V, --version               show program's version number and exit

allowed FORMAT:
  - json
  - xml
  - turtle
  - n3
  - rdf
  - rdf+xml
  - csv
  - tsv
  - json-ld

allowed METHOD:
  - POST
  - GET

allowed AUTH:
  - BASIC
  - DIGEST

$ rqw -e https://lindas.admin.ch/query -Q "SELECT DISTINCT ?x WHERE { ?x ?y ?z . } LIMIT 1" -m POST
x
http://classifications.data.admin.ch/canton/bl
```