### PR TITLE
Replace module level dunders with setuptools keywords

### DIFF
--- a/SPARQLWrapper/__init__.py
+++ b/SPARQLWrapper/__init__.py
@@ -12,21 +12,6 @@ format.
 __version__ = "1.9.0.dev0"
 """The version of SPARQLWrapper"""
 
-__authors__ = "Ivan Herman, Sergio Fernández, Carlos Tejo Alonso, Alexey Zakhlestin"
-"""The primary authors of SPARQLWrapper"""
-
-__license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/copyright-software"
-"""The license governing the use and distribution of SPARQLWrapper"""
-
-__url__ = "http://rdflib.github.io/sparqlwrapper"
-"""The URL for SPARQLWrapper's homepage"""
-
-__contact__ = "rdflib-dev@googlegroups.com"
-"""Mail list to contact to other people RDFLib and SPARQLWrappers folks and developers"""
-
-__date__ = "2019-04-18"
-"""Last update"""
-
 __agent__ = "sparqlwrapper %s (rdflib.github.io/sparqlwrapper)" % __version__
 
 
@@ -36,5 +21,6 @@ from .Wrapper import GET, POST
 from .Wrapper import SELECT, CONSTRUCT, ASK, DESCRIBE, INSERT, DELETE
 from .Wrapper import URLENCODED, POSTDIRECTLY
 from .Wrapper import BASIC, DIGEST
+
 from .SmartWrapper import SPARQLWrapper2
 from .sparql_dataframe import get_sparql_dataframe

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,3 @@ keepalive =
 [options.entry_points]
 console_scripts =
     rqw = SPARQLWrapper.main:main
-
-[mypy]
-python_version = 3.7
-show_error_codes = True
-strict = True
-pretty = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,9 @@ version = attr: SPARQLWrapper.__init__.__version__
 description = SPARQL Endpoint interface to Python
 long_description = This is a wrapper around a SPARQL service. It helps in creating the query URI and, possibly, convert the result into a more manageable format.
 license = W3C SOFTWARE NOTICE AND LICENSE
-author = attr: SPARQLWrapper.__init__.__authors__
-author_email = attr: SPARQLWrapper.__init__.__contact__
-url = attr: SPARQLWrapper.__init__.__url__
+author = Ivan Herman, Sergio Fernández, Carlos Tejo Alonso, Alexey Zakhlestin
+author_email = rdflib-dev@googlegroups.com
+url = http://rdflib.github.io/sparqlwrapper
 download_url = https://github.com/RDFLib/sparqlwrapper/releases
 platforms =
     any

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SPARQLWrapper
-version = attr: SPARQLWrapper.__init__.__version__
+version = attr: SPARQLWrapper.__version__
 description = SPARQL Endpoint interface to Python
 long_description = This is a wrapper around a SPARQL service. It helps in creating the query URI and, possibly, convert the result into a more manageable format.
 license = W3C SOFTWARE NOTICE AND LICENSE
@@ -49,3 +49,9 @@ keepalive =
 [options.entry_points]
 console_scripts =
     rqw = SPARQLWrapper.main:main
+
+[mypy]
+python_version = 3.7
+show_error_codes = True
+strict = True
+pretty = True


### PR DESCRIPTION
Module level dunders are not standardized in any way while setuptools at least has a well defined set of keywords, for this reason it makes more sense to use setuptools keywords instead.

Also:

- Correct the reference to `__version__` - before it was referenced via __init__ - but it should be referenced via the module that __init__ pertains to.

PR extracted from #197 and authored by @eggplants 