### PR TITLE
Fix CLI error reporting

### DIFF
--- a/SPARQLWrapper/main.py
+++ b/SPARQLWrapper/main.py
@@ -27,7 +27,7 @@ def check_file(v):
     elif v == "-":
         return "-"  # stdin
     else:
-        raise argparse.ArgumentError("file '%s' is not found" % v)
+        raise argparse.ArgumentTypeError("file '%s' is not found" % v)
 
 
 def choicesDescriptions():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -88,7 +88,7 @@ class SPARQLWrapperCLIParser_Test(SPARQLWrapperCLI_Test_Base):
         self.assertEqual(cm.exception.code, 2)
         self.assertEqual(
             sys.stderr.getvalue().split("\n")[1],
-            "rqw: error: argument -f/--file: invalid check_file value: '440044.rq'",
+            "rqw: error: argument -f/--file: file '440044.rq' is not found",
         )
 
 


### PR DESCRIPTION
`check_file` is used as an `argparse` type, and as mentioned by the `argparse` docs:

https://docs.python.org/3/library/argparse.html#type

> The argument to type can be any callable that accepts a single string. If the function raises ArgumentTypeError, TypeError, or ValueError, the exception is caught and a nicely formatted error message is displayed. No other exception types are handled.

This changes `check_file` to raise `ArgumentTypeError` so that the error gets reported correctly.

PR extracted from #197 and authored by @eggplants 