### PR TITLE
Fix version in default user agent

### DIFF
--- a/SPARQLWrapper/__init__.py
+++ b/SPARQLWrapper/__init__.py
@@ -12,7 +12,7 @@ format.
 __version__ = "2.0.1a0"
 """The version of SPARQLWrapper"""
 
-__agent__: str = f"sparqlwrapper {__version__} (rdflib.github.io/sparqlwrapper)"
+__agent__: str = f"sparqlwrapper/{__version__} (rdflib.github.io/sparqlwrapper)"
 
 
 from .SmartWrapper import SPARQLWrapper2


### PR DESCRIPTION
According to the RFCs ([1][1], [2][2]), the version is supposed to be separated
from the product by a slash, not by a space.

[1]: https://datatracker.ietf.org/doc/html/rfc2616#section-3.8
[2]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3