### PR TITLE
Fix `test_cli` that were failing because the endpoint http://ja.dbpedia.org/sparql is down

### DIFF
--- a/test/test.rq
+++ b/test/test.rq
@@ -2,8 +2,5 @@ PREFIX dbo: <http://dbpedia.org/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?pllabel
 WHERE {
-  ?pl
-    a dbo:ProgrammingLanguage;
-    rdfs:label ?pllabel.
-  FILTER(SUBSTR(STR(?pllabel), 1, 5) = "PARLO")
-} ORDER BY ?pllabel LIMIT 1
+  ?pl rdfs:label ?pllabel.
+} LIMIT 3


### PR DESCRIPTION
Now these tests are using the main dbpedia and are not anymore checking for exact value returned (instead just checking if there are results)

That said, of course there can't be a single day without an endpoint going down (what a joke, this is so unreliable, I really wonder why SPARQL is not more popular 🤔), so while I fixed thi the LOV fuseki endpoint went down (https://lov.linkeddata.es/dataset/lov/sparql), returning this error: 

```
urllib.error.URLError: <urlopen error [Errno 54] Connection reset by peer>
```

Not going to fix this one. Not worth it, I prefer put the time I have for this on rdflib SPARQLStore.

It will probably go back up soon since I think it's actually used by people (unlike dbpedia)

You'll need to manually trigger the tests when it's back up @nicholascar 