### PR TITLE
Add validation for SELECT query return formats

### DIFF
--- a/SPARQLWrapper/Wrapper.py
+++ b/SPARQLWrapper/Wrapper.py
@@ -760,6 +760,7 @@ class SPARQLWrapper(object):
         <https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1>`_
         """
         if self.queryType in [SELECT, ASK]:
+            unsupportedReturnTypesForSelectQueries = [RDF, RDFXML, TURTLE, N3, JSONLD]
             if self.returnFormat == XML:
                 acceptHeader = ",".join(_SPARQL_XML)
             elif self.returnFormat == JSON:
@@ -774,6 +775,8 @@ class SPARQLWrapper(object):
             ):  # Allowed for SELECT and ASK (https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/#query-success)
                 # but only described for SELECT (https://www.w3.org/TR/sparql11-results-csv-tsv/)
                 acceptHeader = ",".join(_TSV)
+            elif (self.queryType == SELECT and  self.returnFormat in unsupportedReturnTypesForSelectQueries):
+                raise ValueError(self.returnFormat.upper() + " is not a valid return format for SELECT queries. Supported formats include: %s" % ", ".join([i for i in _allowedFormats if i not in unsupportedReturnTypesForSelectQueries]))
             else:
                 acceptHeader = ",".join(_ALL)
                 warnings.warn(

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -205,6 +205,8 @@ class SPARQLWrapper_Test(unittest.TestCase):
         self.wrapper.setReturnFormat(JSON)
         self.assertEqual(JSON, self.wrapper.query().requestedFormat)
 
+        # JSONLD is not supported for SELECT queries, so we need to use a different query type
+        self.wrapper.setQuery("CONSTRUCT WHERE { ?s ?p ?o }")
         self.wrapper.setReturnFormat(JSONLD)
         self.assertEqual(JSONLD, self.wrapper.query().requestedFormat)
 
@@ -220,6 +222,46 @@ class SPARQLWrapper_Test(unittest.TestCase):
         self.assertFalse(self.wrapper.supportsReturnFormat("nonexistent format"))
 
         self.assertTrue(self.wrapper.supportsReturnFormat(JSONLD))
+
+    def testSelectQueryWithRDFFormatsRaisesValueError(self):
+        """Test that SELECT queries with RDF formats raise ValueError"""
+        # Set up a SELECT query
+        self.wrapper.setQuery("SELECT * WHERE { ?s ?p ?o }")
+        
+        # Test that RDF formats raise ValueError for SELECT queries
+        rdf_formats = [RDF, RDFXML, TURTLE, N3, JSONLD]
+        
+        for format_type in rdf_formats:
+            with self.subTest(format=format_type):
+                self.wrapper.setReturnFormat(format_type)
+                # The error should be raised when trying to get the accept header
+                with self.assertRaises(ValueError) as context:
+                    self._get_request(self.wrapper)
+                
+                # Verify the error message contains the format name and mentions SELECT queries
+                error_message = str(context.exception)
+                print(error_message)
+                self.assertIn(format_type.upper(), error_message)
+                self.assertIn("SELECT queries", error_message)
+                self.assertIn("not a valid return format", error_message)
+
+    def testSelectQueryWithValidFormatsWorks(self):
+        """Test that SELECT queries with valid formats work correctly"""
+        # Set up a SELECT query
+        self.wrapper.setQuery("SELECT * WHERE { ?s ?p ?o }")
+        
+        # Test that valid formats for SELECT queries work
+        valid_formats = [XML, JSON, CSV, TSV]
+        
+        for format_type in valid_formats:
+            with self.subTest(format=format_type):
+                self.wrapper.setReturnFormat(format_type)
+                # This should not raise an error
+                try:
+                    request = self._get_request(self.wrapper)
+                    self.assertIsNotNone(request)
+                except ValueError:
+                    self.fail(f"Valid format {format_type} should not raise ValueError for SELECT queries")
 
     def testAddParameter(self):
         self.assertFalse(self.wrapper.addParameter("query", "dummy"))


### PR DESCRIPTION
## Overview
This PR adds validation to prevent semantically incorrect usage of RDF return formats with SELECT queries in SPARQLWrapper. SELECT queries return result sets, not RDF graphs, so requesting RDF formats like RDF/XML, Turtle, N3, or JSON-LD is semantically incorrect and can lead to confusing server errors.

This PR is a compilation of #220 #218 solutions for #190 issue

## Changes Made

### Core Changes
- **Added validation logic** in `SPARQLWrapper/Wrapper.py`:
  - Defined `unsupportedReturnTypesForSelectQueries = [RDF, RDFXML, TURTLE, N3, JSONLD]`
  - Added validation in `_getAcceptHeader()` method to raise `ValueError` when RDF formats are used with SELECT queries
  - Clear error message indicates the invalid format and lists supported formats

### Test Coverage
- **Added comprehensive test suite** in `test/test_wrapper.py`:
  - `testSelectQueryWithRDFFormatsRaisesValueError`: Tests that all RDF formats raise appropriate ValueError
  - `testSelectQueryWithValidFormatsWorks`: Ensures valid formats (XML, JSON, CSV, TSV) work correctly
  - Fixed existing test that was affected by the new validation

## Motivation
- **Prevents user confusion**: Users often accidentally request RDF formats for SELECT queries, leading to server errors or unexpected behavior
- **Semantic correctness**: SELECT queries return result sets, not RDF graphs, so RDF formats are conceptually wrong
- **Better error messages**: Instead of cryptic server errors, users get clear, actionable error messages

## Breaking Changes
⚠️ **This is a breaking change** for existing code that incorrectly uses RDF formats with SELECT queries. Such code will now raise a `ValueError` instead of sending invalid requests to the server.

## Testing
- [x] Unit tests pass
- [x] All existing tests continue to pass
- [x] New validation tests cover both error and success cases
- [x] Manual testing completed

## Example
```python
# This will now raise a ValueError with a clear message:
wrapper = SPARQLWrapper("http://example.org/sparql")
wrapper.setQuery("SELECT * WHERE { ?s ?p ?o }")
wrapper.setReturnFormat(TURTLE)  # Raises ValueError!
```

**Error message:** `TURTLE is not a valid return format for SELECT queries. Supported formats include: json, xml, csv, tsv`

## Related Issues
This addresses the semantic issue where users could request inappropriate return formats for SELECT queries, which could lead to confusing server responses or errors.
