### PR TITLE
Fix command line script name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Command Line Script
 
 To use as a command line script, you will need to install SPARQLWrapper and then
 a command line script called ``rqw`` (spaRQl Wrapper) will be available within the
-Python environment into which it is installed. run ``$ rql -h`` to see all the
+Python environment into which it is installed. run ``$ rqw -h`` to see all the
 script's options.
 
 Python package


### PR DESCRIPTION
Replace `rql` with `rqw` in README.

Correct name is `rqw`. See:
https://github.com/RDFLib/sparqlwrapper/blob/2a4cf12514e551b1b741f953ba49d42eca006beb/setup.cfg#L67-L69